### PR TITLE
Updated to MPAS-Analysis v0.6.5

### DIFF
--- a/bash_scripts/aprime_atm_diags.bash
+++ b/bash_scripts/aprime_atm_diags.bash
@@ -12,7 +12,6 @@ if [ ! -d $remap_files_dir ]; then
   echo "remap_files_dir $remap_files_dir does not exist! Please check." 
   echo "Exiting atmosphere diagnostics ..."
   echo 
-  echo
   exit 1
 fi
 
@@ -28,7 +27,6 @@ if [ ! -f $CERES_EBAF_regrid_wgt_file ]; then
   echo "CERES_EBAF_regid_wgt_file $CERES_EBAF_regrid_wgt_file does not exist! Please check."
   echo "Exiting atmosphere diagnostics ..."
   echo 
-  echo
   exit 1
 fi
 
@@ -36,7 +34,6 @@ if [ ! -f $ERS_regrid_wgt_file ]; then
   echo "ERS_regrid_wgt_file $ERS_regrid_wgt_file does not exist! Please check."
   echo "Exiting atmosphere diagnostics ..."
   echo 
-  echo
   exit 1
 fi
 
@@ -149,7 +146,7 @@ while [ $j -lt $n_cases ]; do
 
    if [ $compute_climo -eq 1 ]; then
      echo
-     echo "Submitting jobs to compute seasonal climatology for $casename"
+     echo "Computing seasonal climatology for $casename"
      echo "Log files in $log_dir/climo_$casename..."
      echo
      ./bash_scripts/compute_climo.bash $scratch_dir \
@@ -178,7 +175,7 @@ while [ $j -lt $n_cases ]; do
 
    if [ $remap_climo -eq 1 ]; then
      echo
-     echo "Submitting jobs to remap seasonal climatology files for $casename" 
+     echo "Remapping seasonal climatology files for $casename" 
      echo "Log files in $log_dir/remap_climo_$casename..."
      echo
      ./bash_scripts/remap_climo_nco.bash $scratch_dir \
@@ -198,7 +195,7 @@ echo
 
 # Plot climatologies and differences
 echo
-echo "Submitting jobs to plot seasonal climatology and differences"
+echo "Plotting seasonal climatology and differences"
 echo "Log files in $log_dir/plot_climo..."
 echo
 
@@ -313,7 +310,7 @@ while [ $j -lt $n_cases ]; do
 
    if [ $remap_ts -eq 1 ]; then
      echo
-     echo "Submitting jobs to interpolate time series files for $casename"
+     echo "Interpolating time series files for $casename"
      echo "Log files in $log_dir/remap_time_series_${casename}..."
      echo
      ./bash_scripts/remap_time_series_nco.bash $scratch_dir \
@@ -330,7 +327,7 @@ done
 
 # Plot trends for different regions
 echo
-echo "Submitting jobs to plot time series"
+echo "Plotting time series"
 echo "Log files in $log_dir/"
 echo
 
@@ -361,8 +358,6 @@ while [ $j -lt $n_test_cases ]; do
 
    j=$((j+1))
 done
-
-
 
 
 # ENSO DIAGS
@@ -433,7 +428,7 @@ if [ $generate_atm_enso_diags == 1 ]; then
 
 	   if [ $compute_climo -eq 1 ]; then
 	     echo
-	     echo "Submitting jobs to compute seasonal climatology for $casename"
+	     echo "Computing seasonal climatology for $casename"
 	     echo "Log files in $log_dir/climo_$casename..."
 	     echo
 	     ./bash_scripts/compute_climo.bash $scratch_dir \
@@ -462,7 +457,7 @@ if [ $generate_atm_enso_diags == 1 ]; then
 
 	   if [ $remap_climo -eq 1 ]; then
 	     echo
-	     echo "Submitting jobs to remap seasonal climatology files for $casename" 
+	     echo "Remapping seasonal climatology files for $casename" 
 	     echo "Log files in $log_dir/remap_climo_$casename..."
 	     echo
 	     ./bash_scripts/remap_climo_nco.bash $scratch_dir \
@@ -483,7 +478,7 @@ if [ $generate_atm_enso_diags == 1 ]; then
         # ENSO Diags: Plot Meridional Average over the Tropical Pacific
         echo
         echo
-        echo Submitting jobs to plot meridional average over the Tropical Pacific
+        echo Plotting meridional average over the Tropical Pacific
         echo Log files in $log_dir/
         echo
 
@@ -582,7 +577,7 @@ if [ $generate_atm_enso_diags == 1 ]; then
 
                 if [ $remap_ts -eq 1 ]; then
                         echo
-                        echo Submitting jobs to interpolate time series files for $casename
+                        echo Interpolating time series files for $casename
                         echo Log files in $log_dir/remap_time_series_${casename}...
                         echo
                         bash_scripts/remap_time_series_nco.bash $scratch_dir \
@@ -600,7 +595,7 @@ if [ $generate_atm_enso_diags == 1 ]; then
 
         # ENSO Diags: Compute Nino and EQSOI indices
         echo
-        echo Submitting jobs to compute Nino and EQSOI index
+        echo Computing Nino and EQSOI index
         echo Log files in $log_dir/
         echo
 
@@ -665,7 +660,7 @@ if [ $generate_atm_enso_diags == 1 ]; then
         # ENSO Diags: Plot Nino and EQSOI time series 
  
         echo 
-        echo Submitting job to plot Nino and EQSOI index 
+        echo Plotting Nino and EQSOI index 
         echo Log files in $log_dir/ 
         echo 
  
@@ -696,7 +691,7 @@ if [ $generate_atm_enso_diags == 1 ]; then
 
         # ENSO Diags: Plot Nino3, Nino3.4 and Nino4 index time series
         echo
-        echo Submitting jobs to plot Nino3, Nino3.4 and Nino4 time series
+        echo Plotting Nino3, Nino3.4 and Nino4 time series
         echo Log files in $log_dir/
         echo
 
@@ -737,7 +732,7 @@ if [ $generate_atm_enso_diags == 1 ]; then
 
         # ENSO Diags: Plot Nino3, Nino3.4 and Nino4 index seasonality
         echo
-        echo Submitting jobs to plot seasonality of Nino indices
+        echo Plotting seasonality of Nino indices
         echo Log files in $log_dir/
         echo
 
@@ -776,7 +771,7 @@ if [ $generate_atm_enso_diags == 1 ]; then
 	split_yfit_x_0=0
 
         echo
-        echo Submitting jobs to plot Bjerkenes feedback
+        echo Plotting Bjerkenes feedback
         echo Log files in $log_dir/
         echo
 
@@ -823,7 +818,7 @@ if [ $generate_atm_enso_diags == 1 ]; then
 	split_yfit_x_0=1
 
         echo
-        echo Submitting jobs to plot Nino3 heat flux-SST feedbacks
+        echo Plotting Nino3 heat flux-SST feedbacks
         echo Log files in $log_dir/
         echo
 
@@ -868,9 +863,8 @@ if [ $generate_atm_enso_diags == 1 ]; then
 	field_reg='global'
 	field_reg_name='global'
 
-
         echo
-        echo Submitting jobs to plot regression of variables against the $index_reg index
+        echo Plotting regression of variables against the $index_reg index
         echo Log files in $log_dir/
         echo
 
@@ -907,7 +901,7 @@ if [ $generate_atm_enso_diags == 1 ]; then
 
         #ENSO Diags: Plot std. dev. over the Tropical Pacific
         echo
-        echo Submitting jobs to plot std. dev. of fields over the Tropical Pacific
+        echo Plotting std. dev. of fields over the Tropical Pacific
         echo Log files in $log_dir/
 
         var_list_file=bash_scripts/var_list_enso_diags_time_series.bash
@@ -949,7 +943,7 @@ if [ $generate_atm_enso_diags == 1 ]; then
 
 
         echo
-        echo Submitting jobs to plot ENSO evolution: Lead lag regression of TAUX and TS against the Nino3.4 index
+        echo Plotting ENSO evolution: Lead lag regression of TAUX and TS against the Nino3.4 index
         echo Log files in $log_dir/
         echo
 
@@ -984,8 +978,6 @@ if [ $generate_atm_enso_diags == 1 ]; then
 	done
 
 fi
-
-
 
 echo
 echo "Completed atmosphere diagnostics!"

--- a/bash_scripts/aprime_ocnice_diags.bash
+++ b/bash_scripts/aprime_ocnice_diags.bash
@@ -24,9 +24,17 @@ unset tmp_currentdir tmp_gittopdir
 
 export config_file="$log_dir/config.ocnice.$uniqueID"
 python python/setup_ocnice_config.py
-if [ $? -ne 0 ]; then
+exstatus=$?
+if [ $exstatus -ne 0 ]; then
+  echo
   echo "Failed to build config.ocnice"
   exit 1
 fi
 
 python python/MPAS-Analysis/run_mpas_analysis.py $config_file
+exstatus=$?
+if [ $exstatus -ne 0 ]; then
+  echo
+  echo "Failed some ocean/ice diagnostic tasks"
+  exit 1
+fi

--- a/bash_scripts/batch_atm.anvil.bash
+++ b/bash_scripts/batch_atm.anvil.bash
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Copyright (c) 2017, UT-BATTELLE, LLC
+# All rights reserved.
+# 
+# This software is released under the BSD license detailed
+# in the LICENSE file in the top level a-prime directory
+#
+
+#PBS -q acme 
+#PBS -l nodes=1
+#PBS -l walltime=01:00:00
+#PBS -A ACME
+#PBS -N aprime_atm_diags
+#PBS -o aprime_atm_diags.o$PBS_JOBID
+#PBS -e aprime_atm_diags.e$PBS_JOBID
+#PBS -V
+
+cd $PBS_O_WORKDIR
+
+./bash_scripts/aprime_atm_diags.bash
+
+echo
+echo "**** The following batch job will be submitted to cp files to www_dir *if* the atm diags are completed"
+echo "**** jobID:"
+batch_script="./bash_scripts/batch_update_wwwdir.$machname.bash"
+qsub -W depend=afterok:$PBS_JOBID $batch_script

--- a/bash_scripts/batch_ocnice.anvil.bash
+++ b/bash_scripts/batch_ocnice.anvil.bash
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Copyright (c) 2017, UT-BATTELLE, LLC
+# All rights reserved.
+# 
+# This software is released under the BSD license detailed
+# in the LICENSE file in the top level a-prime directory
+#
+
+#PBS -q acme 
+#PBS -l nodes=1
+#PBS -l walltime=01:00:00
+#PBS -A ACME
+#PBS -N aprime_ocnice_diags
+#PBS -o aprime_ocnice_diags.o$PBS_JOBID
+#PBS -e aprime_ocnice_diags.e$PBS_JOBID
+#PBS -V
+
+cd $PBS_O_WORKDIR
+
+export command_prefix=""
+
+unset LD_LIBRARY_PATH
+soft add +acme-unified-1.1.1-x
+
+./bash_scripts/aprime_ocnice_diags.bash
+
+echo
+echo "**** The following batch job will be submitted to cp files to www_dir *if* the ocn/ice diags are completed"
+echo "**** jobID:"
+batch_script="./bash_scripts/batch_update_wwwdir.$machname.bash"
+qsub -W depend=afterok:$PBS_JOBID $batch_script

--- a/bash_scripts/batch_ocnice.lanl.bash
+++ b/bash_scripts/batch_ocnice.lanl.bash
@@ -7,9 +7,7 @@
 # in the LICENSE file in the top level a-prime directory
 #
 
-# change number of nodes to change the number of parallel tasks
-# (anything between 1 and the total number of tasks to run)
-#SBATCH --nodes=10
+#SBATCH --nodes=1
 #SBATCH --time=01:00:00
 #SBATCH --account=climateacme
 #SBATCH --job-name=aprime_ocnice_diags

--- a/bash_scripts/batch_ocnice.nersc.bash
+++ b/bash_scripts/batch_ocnice.nersc.bash
@@ -8,9 +8,7 @@
 #
 
 #SBATCH --partition=regular
-# change number of nodes to change the number of parallel tasks
-# (anything between 1 and the total number of tasks to run)
-#SBATCH --nodes=10
+#SBATCH --nodes=1
 #SBATCH --time=01:00:00
 #SBATCH --account=acme
 #SBATCH --job-name=aprime_ocnice_diags

--- a/bash_scripts/batch_ocnice.olcf.bash
+++ b/bash_scripts/batch_ocnice.olcf.bash
@@ -8,9 +8,7 @@
 #
 
 #PBS -q batch
-# change number of nodes to change the number of parallel tasks
-# (anything between 1 and the total number of tasks to run)
-#PBS -l nodes=10
+#PBS -l nodes=1
 #PBS -l walltime=01:00:00
 #PBS -A cli115
 #PBS -N aprime_ocnice_diags

--- a/bash_scripts/batch_update_wwwdir.anvil.bash
+++ b/bash_scripts/batch_update_wwwdir.anvil.bash
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright (c) 2017, UT-BATTELLE, LLC
+# All rights reserved.
+# 
+# This software is released under the BSD license detailed
+# in the LICENSE file in the top level a-prime directory
+#
+
+#PBS -q acme 
+#PBS -l nodes=1
+#PBS -l walltime=00:20:00
+#PBS -A ACME
+#PBS -N aprime_update_wwwdir
+#PBS -o aprime_update_wwwdir.o$PBS_JOBID
+#PBS -e aprime_update_wwwdir.e$PBS_JOBID
+#PBS -V
+
+# Update www/plots directory with newly generated plots
+cp -u $plots_dir/* $www_dir/$plots_dir_name
+chmod -R ga+rX $www_dir/$plots_dir_name
+echo
+echo "Updated atm plots in website directory: $www_dir/$plots_dir_name"
+echo

--- a/bash_scripts/compute_climo.bash
+++ b/bash_scripts/compute_climo.bash
@@ -50,6 +50,12 @@ if [ "$casename" != "obs" ]; then
 						    --end_month $end_month \
 						    --begin_yr $begin_yr \
 						    --end_yr $end_yr >& $log_dir/climo_${casename}_${var}_${season_name}_years$begin_yr-$end_yr.log &
+                exstatus=$?
+                if [ $exstatus -ne 0 ]; then
+                  echo
+                  echo "Failed computing climatologies for season $ns"
+                  exit 1
+                fi
 
 	fi
 

--- a/bash_scripts/compute_eqsoi_index.bash
+++ b/bash_scripts/compute_eqsoi_index.bash
@@ -15,18 +15,15 @@ end_yr=$5
 var_list_file=$6
 
 
-
 # Read in variable list for plotting climatologies  diagnostics
-
 source $var_list_file
 
 n_var=${#var_set[@]}
- 
+
 index_set_name=EQSOI
 
 regs=('EPAC' 'INDO')
 names=('EPAC' 'INDO')
-
 
 # Compute indices
 for ((k=0; k<$n_var; k++)); do
@@ -64,9 +61,14 @@ for ((k=0; k<$n_var; k++)); do
 							--no_ann 1 \
 							--stdize 1 \
 							--write_netcdf 1 >& $log_dir/compute_index_${casename}_${var}_$index_set_name.log &
+       exstatus=$?
+       if [ $exstatus -ne 0 ]; then
+         echo
+         echo "Failed computing Nino eqsoi_index"
+         exit 1
+       fi
 
 done
-
 
 echo
 echo Waiting for jobs to complete ...
@@ -75,7 +77,3 @@ echo
 wait
 echo ... Done.
 echo
-
- 	
-
-

--- a/bash_scripts/compute_indices.bash
+++ b/bash_scripts/compute_indices.bash
@@ -74,10 +74,14 @@ for ((i=0; i<$n_index; i++)); do
 							--no_ann 1 \
 							--stdize 0 \
 							--write_netcdf 1 >& $log_dir/compute_index_${case}_$index_name.log &
+       exstatus=$?
+       if [ $exstatus -ne 0 ]; then
+         echo
+         echo "Failed computing Nino indeces"
+         exit 1
+       fi
 
 done
-
-
 
 echo
 echo Waiting for jobs to complete ...
@@ -86,6 +90,3 @@ echo
 wait
 
 echo ...Done.
- 	
-
-

--- a/bash_scripts/condense_field_bundle.bash
+++ b/bash_scripts/condense_field_bundle.bash
@@ -21,7 +21,7 @@ fi
 source $var_set_file
 
 echo
-echo "Submitting jobs to condense $casename fields:"
+echo "Condensing $casename fields:"
 echo "${var_set[@]}"
 echo
 echo "Log files in $log_dir/condense_field_${casename}...log"

--- a/bash_scripts/generate_html_index_file.bash
+++ b/bash_scripts/generate_html_index_file.bash
@@ -178,36 +178,53 @@ EOF
 fi
 
 if [ $generate_ocnice_diags -eq 1 ]; then
-  # Generating time series ocn/ice part of index.html file
-  cat >> index.html << EOF
-  <br>
-  <br>
-  </TABLE>
-  <hr noshade size=2 size="100%">
+  if [ $generate_ohc_trends -eq 1 ] || \
+     [ $generate_sst_trends -eq 1 ] || \
+     [ $generate_seaice_trends -eq 1 ]; then
+       
+    # Generating time series ocn/ice part of index.html file
+    cat >> index.html << EOF
+    <br>
+    <br>
+    </TABLE>
+    <hr noshade size=2 size="100%">
 
-  <font color=red size=+1><b>Time Series Plots: Global/Hemispheric means (OCN/ICE)</b></font>
-  </b></font>
+    <font color=red size=+1><b>Time Series Plots: Global/Hemispheric means (OCN/ICE)</b></font>
+    </b></font>
 
-  <div style="text-align:left">
-  <font color=peru size=-1>$casename (Years: $begin_yr_ts-$end_yr_ts)</font><br>
-  </div>
+    <div style="text-align:left">
+    <font color=peru size=-1>$casename (Years: $begin_yr_ts-$end_yr_ts)</font><br>
+    </div>
 
-  <hr noshade size=2 size="100%">
+    <hr noshade size=2 size="100%">
 
-  <TABLE>
-  <TR>
-    <TH ALIGN=LEFT><A HREF="sst_global_${casename}.png">Global SST</a>
-  <TR>
-    <TH ALIGN=LEFT><A HREF="OHCAnomaly_global_${casename}.png">Global OHC</a>
-  <TR>
-    <TH ALIGN=LEFT><A HREF="iceAreaNH_${casename}.png">NH Ice Area</a>
-  <TR>
-    <TH ALIGN=LEFT><A HREF="iceAreaSH_${casename}.png">SH Ice Area</a>
-  <TR>
-    <TH ALIGN=LEFT><A HREF="iceVolumeNH_${casename}.png">NH Ice Volume</a>
-  <TR>
-    <TH ALIGN=LEFT><A HREF="iceVolumeSH_${casename}.png">SH Ice Volume</a>
+    <TABLE>
 EOF
+    if [ $generate_sst_trends -eq 1 ]; then
+      cat >> index.html << EOF
+      <TR>
+        <TH ALIGN=LEFT><A HREF="sst_global_${casename}.png">Global SST</a>
+EOF
+    fi
+    if [ $generate_ohc_trends -eq 1 ]; then
+      cat >> index.html << EOF
+      <TR>
+        <TH ALIGN=LEFT><A HREF="OHCAnomaly_global_${casename}.png">Global OHC</a>
+EOF
+    fi
+    if [ $generate_seaice_trends -eq 1 ]; then
+      cat >> index.html << EOF
+      <TR>
+        <TH ALIGN=LEFT><A HREF="iceAreaNH_${casename}.png">NH Ice Area</a>
+      <TR>
+        <TH ALIGN=LEFT><A HREF="iceAreaSH_${casename}.png">SH Ice Area</a>
+      <TR>
+        <TH ALIGN=LEFT><A HREF="iceVolumeNH_${casename}.png">NH Ice Volume</a>
+      <TR>
+        <TH ALIGN=LEFT><A HREF="iceVolumeSH_${casename}.png">SH Ice Volume</a>
+EOF
+    fi
+  fi
 fi
 
 
@@ -316,184 +333,226 @@ EOF
 fi
 
 if [ $generate_ocnice_diags -eq 1 ]; then
-  # Generating climatology (ocn/ice) part of index.html file
-  cat >> index.html << EOF
-  <TR>
-  <TD><BR>
-  <hr noshade size=2 size="100%">
-  <font color=red size=+1><b>Climatology Plots (OCN/ICE)</b></font>
-
-  <div style="text-align:left">
-  <font color=peru size=-1>$casename (Years: $begin_yr_climo-$end_yr_climo)</font><br>
-  <font color=peru size=-1>$ref_case_text</font>
-  </div>
-
-  <hr noshade size=2 size="100%">
-  <TABLE>
-  <TR>
-    <TH ALIGN=LEFT><font color=green size=+1>Global Ocean</font>
-  <TR>
-    <TH><BR>
-    <TH ALIGN=LEFT><font color=brown size=+1>SST Hadley-NOAA-OI</font>
-    <TH>JFM
-    <TH>JAS
-    <TH>ANN
-  <TR>
-  <TH ALIGN=LEFT>SST
-  <TH><BR>
-  <TD ALIGN=LEFT><A HREF="sstHADOI_${casename}_JFM_years${begin_yr}-${end_yr}.png">plot</a>
-  <TD ALIGN=LEFT><A HREF="sstHADOI_${casename}_JAS_years${begin_yr}-${end_yr}.png">plot</a>
-  <TD ALIGN=LEFT><A HREF="sstHADOI_${casename}_ANN_years${begin_yr}-${end_yr}.png">plot</a>
-  <TR>
-    <TH><BR>
-    <TH ALIGN=LEFT><font color=brown size=+1>SSS Aquarius</font>
-    <TH>JFM
-    <TH>JAS
-    <TH>ANN
-  <TR>
-    <TH ALIGN=LEFT>SSS
-    <TH><BR>
-    <TD ALIGN=LEFT><A HREF="sssAquarius_${casename}_JFM_years${begin_yr}-${end_yr}.png">plot</a>
-    <TD ALIGN=LEFT><A HREF="sssAquarius_${casename}_JAS_years${begin_yr}-${end_yr}.png">plot</a>
-    <TD ALIGN=LEFT><A HREF="sssAquarius_${casename}_ANN_years${begin_yr}-${end_yr}.png">plot</a>
-  <TR>
-    <TH><BR>
-    <TH ALIGN=LEFT><font color=brown size=+1>MLD Holte-Talley ARGO</font>
-    <TH>JFM
-    <TH>JAS
-    <TH>ANN
-  <TR>
-    <TH ALIGN=LEFT>MLD
-    <TH><BR>
-    <TD ALIGN=LEFT><A HREF="mldHolteTalleyARGO_${casename}_JFM_years${begin_yr}-${end_yr}.png">plot</a>
-    <TD ALIGN=LEFT><A HREF="mldHolteTalleyARGO_${casename}_JAS_years${begin_yr}-${end_yr}.png">plot</a>
-    <TD ALIGN=LEFT><A HREF="mldHolteTalleyARGO_${casename}_ANN_years${begin_yr}-${end_yr}.png">plot</a>
-  <TR>
-    <TH><BR>
-  <TR>
-    <TH ALIGN=LEFT><font color=green size=+1>Northern Hemisphere Sea-ice</font>
-  <TR>
-    <TH><BR>
-    <TH ALIGN=LEFT><font color=brown size=+1>SSM/I NASATeam</font>
-    <TH>JFM
-    <TH>JAS
-  <TR>
-    <TH ALIGN=LEFT>Ice Conc. 
-    <TD ALIGN=LEFT>Ice concentration
-    <TD ALIGN=LEFT><A HREF="iceconcNASATeamNH_${casename}_JFM_years${begin_yr}-${end_yr}.png">plot</a>
-    <TD ALIGN=LEFT><A HREF="iceconcNASATeamNH_${casename}_JAS_years${begin_yr}-${end_yr}.png">plot</a>
-  <TR>
-    <TH><BR>
-    <TH ALIGN=LEFT><font color=brown size=+1>SSM/I Bootstrap</font>
-    <TH>JFM
-    <TH>JAS
-  <TR>
-    <TH ALIGN=LEFT>Ice Conc. 
-    <TD ALIGN=LEFT>Ice concentration
-    <TD ALIGN=LEFT><A HREF="iceconcBootstrapNH_${casename}_JFM_years${begin_yr}-${end_yr}.png">plot</a>
-    <TD ALIGN=LEFT><A HREF="iceconcBootstrapNH_${casename}_JAS_years${begin_yr}-${end_yr}.png">plot</a>
-  <TR>
-    <TH><BR>
-    <TH ALIGN=LEFT><font color=brown size=+1>ICESat</font>
-    <TH>FM
-    <TH>ON
-  <TR>
-    <TH ALIGN=LEFT>Ice Thick. 
-    <TD ALIGN=LEFT>Ice Thickness
-    <TD ALIGN=LEFT><A HREF="icethickNH_${casename}_FM_years${begin_yr}-${end_yr}.png">plot</a>
-    <TD ALIGN=LEFT><A HREF="icethickNH_${casename}_ON_years${begin_yr}-${end_yr}.png">plot</a>
-  <TR>
-    <TH><BR>
-  <TR>
-    <TH ALIGN=LEFT><font color=green size=+1>Southern Hemisphere Sea-ice</font>
-  <TR>
-    <TH><BR>
-    <TH ALIGN=LEFT><font color=brown size=+1>SSM/I NASATeam</font>
-    <TH>DJF
-    <TH>JJA
-  <TR>
-    <TH ALIGN=LEFT>Ice Conc. 
-    <TD ALIGN=LEFT>Ice concentration
-    <TD ALIGN=LEFT><A HREF="iceconcNASATeamSH_${casename}_DJF_years${begin_yr}-${end_yr}.png">plot</a>
-    <TD ALIGN=LEFT><A HREF="iceconcNASATeamSH_${casename}_JJA_years${begin_yr}-${end_yr}.png">plot</a>
-  <TR>
-    <TH><BR>
-    <TH ALIGN=LEFT><font color=brown size=+1>SSM/I Bootstrap</font>
-    <TH>DJF
-    <TH>JJA
-  <TR>
-    <TH ALIGN=LEFT>Ice Conc. 
-    <TD ALIGN=LEFT>Ice concentration
-    <TD ALIGN=LEFT><A HREF="iceconcBootstrapSH_${casename}_DJF_years${begin_yr}-${end_yr}.png">plot</a>
-    <TD ALIGN=LEFT><A HREF="iceconcBootstrapSH_${casename}_JJA_years${begin_yr}-${end_yr}.png">plot</a>
-  <TR>
-    <TH><BR>
-    <TH ALIGN=LEFT><font color=brown size=+1>ICESat</font>
-    <TH>FM
-    <TH>ON
-  <TR>
-    <TH ALIGN=LEFT>Ice Thick. 
-    <TD ALIGN=LEFT>Ice Thickness
-    <TD ALIGN=LEFT><A HREF="icethickSH_${casename}_FM_years${begin_yr}-${end_yr}.png">plot</a>
-    <TD ALIGN=LEFT><A HREF="icethickSH_${casename}_ON_years${begin_yr}-${end_yr}.png">plot</a>
-  <TR>
+  if [ $generate_sst_climo -eq 1 ] || [ $generate_sss_climo -eq 1 ] || \
+     [ $generate_mld_climo -eq 1 ] || [ $generate_seaice_climo -eq 1 ]; then
+    # Generating climatology (ocn/ice) part of index.html file
+    cat >> index.html << EOF
+    <TR>
     <TD><BR>
-  </TABLE>
+    <hr noshade size=2 size="100%">
+    <font color=red size=+1><b>Climatology Plots (OCN/ICE)</b></font>
+
+    <div style="text-align:left">
+    <font color=peru size=-1>$casename (Years: $begin_yr_climo-$end_yr_climo)</font><br>
+    <font color=peru size=-1>$ref_case_text</font>
+    </div>
+
+    <hr noshade size=2 size="100%">
+    <TABLE>
+    <TR>
+      <TH ALIGN=LEFT><font color=green size=+1>Global Ocean</font>
 EOF
-
-  # Generating other ocn/ice part of index.html file
-  cat >> index.html << EOF
-  <hr noshade size=2 size="100%">
-  <font color=red size=+1><b>Other OCN/ICE plots</b></font>
-
-  <div style="text-align:left">
-  <font color=peru size=-1>Time series/Trends for Years: $begin_yr_ts-$end_yr_ts</font><br>
-  <font color=peru size=-1>Climatologies for Years: $begin_yr_climo-$end_yr_climo</font><br>
-  <font color=peru size=-1>Nino3.4 diagnostics for Years: $begin_yr_climateIndex-$end_yr_climateIndex</font>
-  </div>
-
-  <hr noshade size=2 size="100%">
-  <TABLE>
-  <TR>
-    <TH ALIGN=LEFT><font color=green size=+1>Meridional Overturning Circulation (MOC)</font>
-  <TR>
-    <TH ALIGN=LEFT><A HREF="mocGlobal_${casename}_years${begin_yr}-${end_yr}.png">Global Ocean MOC streamfunction</a> 
-  <TR>
-    <TH ALIGN=LEFT><A HREF="mocAtlantic_${casename}_years${begin_yr}-${end_yr}.png">Atlantic Ocean MOC streamfunction</a>
-  <TR>
-    <TH ALIGN=LEFT><A HREF="mocTimeseries_${casename}.png">Time series of Max Atlantic MOC at 26.5N</a>
-  <TR>
-    <TD><BR>
-  <TR>
-    <TD><BR>
-  <TR>
-    <TH ALIGN=LEFT><font color=green size=+1>Meridional Heat Transport (MHT)</font>
-  <TR>
-    <TH ALIGN=LEFT><A HREF="mht_${casename}_years${begin_yr}-${end_yr}.png">Global Ocean MHT</a> 
-  <TR>
-    <TD><BR>
-  <TR>
-    <TD><BR>
-  <TR>
-    <TH ALIGN=LEFT><font color=green size=+1>Nino3.4 Index</font>
-  <TR>
-    <TH ALIGN=LEFT><A HREF="NINO34_${casename}.png">Time series of Nino3.4 Index</a>
-  <TR>
-    <TH ALIGN=LEFT><A HREF="NINO34_spectra_${casename}.png">Nino3.4 Power Spectrum</a>
-  <TR>
-    <TH><BR>
-  <TR>
-    <TH><BR>
-  <TR>
-    <TH ALIGN=LEFT><font color=green size=+1>T, S, OHC anomaly trends with depth</font>
-  <TR>
-    <TH ALIGN=LEFT><A HREF="TAnomalyZ_global_${casename}.png">T anomaly vs depth/time</a>
-  <TR>
-    <TH ALIGN=LEFT><A HREF="SAnomalyZ_global_${casename}.png">S anomaly vs depth/time</a>
-  <TR>
-    <TH ALIGN=LEFT><A HREF="OHCAnomalyZ_global_${casename}.png">OHC anomaly vs depth/time</a>
-  </TABLE>
+    if [ $generate_sst_climo -eq 1 ]; then
+      cat >> index.html << EOF
+      <TR>
+        <TH><BR>
+        <TH ALIGN=LEFT><font color=brown size=+1>SST Hadley-NOAA-OI</font>
+        <TH>JFM
+        <TH>JAS
+        <TH>ANN
+      <TR>
+      <TH ALIGN=LEFT>SST
+      <TH><BR>
+      <TD ALIGN=LEFT><A HREF="sstHADOI_${casename}_JFM_years${begin_yr}-${end_yr}.png">plot</a>
+      <TD ALIGN=LEFT><A HREF="sstHADOI_${casename}_JAS_years${begin_yr}-${end_yr}.png">plot</a>
+      <TD ALIGN=LEFT><A HREF="sstHADOI_${casename}_ANN_years${begin_yr}-${end_yr}.png">plot</a>
 EOF
+    fi
+    if [ $generate_sss_climo -eq 1 ]; then
+      cat >> index.html << EOF
+      <TR>
+        <TH><BR>
+        <TH ALIGN=LEFT><font color=brown size=+1>SSS Aquarius</font>
+        <TH>JFM
+        <TH>JAS
+        <TH>ANN
+      <TR>
+        <TH ALIGN=LEFT>SSS
+        <TH><BR>
+        <TD ALIGN=LEFT><A HREF="sssAquarius_${casename}_JFM_years${begin_yr}-${end_yr}.png">plot</a>
+        <TD ALIGN=LEFT><A HREF="sssAquarius_${casename}_JAS_years${begin_yr}-${end_yr}.png">plot</a>
+        <TD ALIGN=LEFT><A HREF="sssAquarius_${casename}_ANN_years${begin_yr}-${end_yr}.png">plot</a>
+EOF
+    fi
+    if [ $generate_mld_climo -eq 1 ]; then
+      cat >> index.html << EOF
+      <TR>
+        <TH><BR>
+        <TH ALIGN=LEFT><font color=brown size=+1>MLD Holte-Talley ARGO</font>
+        <TH>JFM
+        <TH>JAS
+        <TH>ANN
+      <TR>
+        <TH ALIGN=LEFT>MLD
+        <TH><BR>
+        <TD ALIGN=LEFT><A HREF="mldHolteTalleyARGO_${casename}_JFM_years${begin_yr}-${end_yr}.png">plot</a>
+        <TD ALIGN=LEFT><A HREF="mldHolteTalleyARGO_${casename}_JAS_years${begin_yr}-${end_yr}.png">plot</a>
+        <TD ALIGN=LEFT><A HREF="mldHolteTalleyARGO_${casename}_ANN_years${begin_yr}-${end_yr}.png">plot</a>
+EOF
+    fi
+    if [ $generate_seaice_climo -eq 1 ]; then
+      cat >> index.html << EOF
+      <TR>
+        <TH><BR>
+      <TR>
+        <TH ALIGN=LEFT><font color=green size=+1>Northern Hemisphere Sea-ice</font>
+      <TR>
+        <TH><BR>
+        <TH ALIGN=LEFT><font color=brown size=+1>SSM/I NASATeam</font>
+        <TH>JFM
+        <TH>JAS
+      <TR>
+        <TH ALIGN=LEFT>Ice Conc. 
+        <TD ALIGN=LEFT>Ice concentration
+        <TD ALIGN=LEFT><A HREF="iceconcNASATeamNH_${casename}_JFM_years${begin_yr}-${end_yr}.png">plot</a>
+        <TD ALIGN=LEFT><A HREF="iceconcNASATeamNH_${casename}_JAS_years${begin_yr}-${end_yr}.png">plot</a>
+      <TR>
+        <TH><BR>
+        <TH ALIGN=LEFT><font color=brown size=+1>SSM/I Bootstrap</font>
+        <TH>JFM
+        <TH>JAS
+      <TR>
+        <TH ALIGN=LEFT>Ice Conc. 
+        <TD ALIGN=LEFT>Ice concentration
+        <TD ALIGN=LEFT><A HREF="iceconcBootstrapNH_${casename}_JFM_years${begin_yr}-${end_yr}.png">plot</a>
+        <TD ALIGN=LEFT><A HREF="iceconcBootstrapNH_${casename}_JAS_years${begin_yr}-${end_yr}.png">plot</a>
+      <TR>
+        <TH><BR>
+        <TH ALIGN=LEFT><font color=brown size=+1>ICESat</font>
+        <TH>FM
+        <TH>ON
+      <TR>
+        <TH ALIGN=LEFT>Ice Thick. 
+        <TD ALIGN=LEFT>Ice Thickness
+        <TD ALIGN=LEFT><A HREF="icethickNH_${casename}_FM_years${begin_yr}-${end_yr}.png">plot</a>
+        <TD ALIGN=LEFT><A HREF="icethickNH_${casename}_ON_years${begin_yr}-${end_yr}.png">plot</a>
+      <TR>
+        <TH><BR>
+      <TR>
+        <TH ALIGN=LEFT><font color=green size=+1>Southern Hemisphere Sea-ice</font>
+      <TR>
+        <TH><BR>
+        <TH ALIGN=LEFT><font color=brown size=+1>SSM/I NASATeam</font>
+        <TH>DJF
+        <TH>JJA
+      <TR>
+        <TH ALIGN=LEFT>Ice Conc. 
+        <TD ALIGN=LEFT>Ice concentration
+        <TD ALIGN=LEFT><A HREF="iceconcNASATeamSH_${casename}_DJF_years${begin_yr}-${end_yr}.png">plot</a>
+        <TD ALIGN=LEFT><A HREF="iceconcNASATeamSH_${casename}_JJA_years${begin_yr}-${end_yr}.png">plot</a>
+      <TR>
+        <TH><BR>
+        <TH ALIGN=LEFT><font color=brown size=+1>SSM/I Bootstrap</font>
+        <TH>DJF
+        <TH>JJA
+      <TR>
+        <TH ALIGN=LEFT>Ice Conc. 
+        <TD ALIGN=LEFT>Ice concentration
+        <TD ALIGN=LEFT><A HREF="iceconcBootstrapSH_${casename}_DJF_years${begin_yr}-${end_yr}.png">plot</a>
+        <TD ALIGN=LEFT><A HREF="iceconcBootstrapSH_${casename}_JJA_years${begin_yr}-${end_yr}.png">plot</a>
+      <TR>
+        <TH><BR>
+        <TH ALIGN=LEFT><font color=brown size=+1>ICESat</font>
+        <TH>FM
+        <TH>ON
+      <TR>
+        <TH ALIGN=LEFT>Ice Thick. 
+        <TD ALIGN=LEFT>Ice Thickness
+        <TD ALIGN=LEFT><A HREF="icethickSH_${casename}_FM_years${begin_yr}-${end_yr}.png">plot</a>
+        <TD ALIGN=LEFT><A HREF="icethickSH_${casename}_ON_years${begin_yr}-${end_yr}.png">plot</a>
+      <TR>
+        <TD><BR>
+EOF
+    fi
+    cat >> index.html << EOF
+    </TABLE>
+EOF
+  fi
+
+  if [ $generate_moc -eq 1 ] || [ $generate_mht -eq 1 ] || \
+     [ $generate_nino34 -eq 1 ] || [ $generate_ohc_trends -eq 1 ]; then
+    # Generating other ocn/ice part of index.html file
+    cat >> index.html << EOF
+    <hr noshade size=2 size="100%">
+    <font color=red size=+1><b>Other OCN/ICE plots</b></font>
+
+    <div style="text-align:left">
+    <font color=peru size=-1>Time series/Trends for Years: $begin_yr_ts-$end_yr_ts</font><br>
+    <font color=peru size=-1>Climatologies for Years: $begin_yr_climo-$end_yr_climo</font><br>
+    <font color=peru size=-1>Nino3.4 diagnostics for Years: $begin_yr_climateIndex-$end_yr_climateIndex</font>
+    </div>
+
+    <hr noshade size=2 size="100%">
+    <TABLE>
+EOF
+    if [ $generate_moc -eq 1 ]; then
+      cat >> index.html << EOF
+      <TR>
+        <TH ALIGN=LEFT><font color=green size=+1>Meridional Overturning Circulation (MOC)</font>
+      <TR>
+        <TH ALIGN=LEFT><A HREF="mocGlobal_${casename}_years${begin_yr}-${end_yr}.png">Global Ocean MOC streamfunction</a> 
+      <TR>
+        <TH ALIGN=LEFT><A HREF="mocAtlantic_${casename}_years${begin_yr}-${end_yr}.png">Atlantic Ocean MOC streamfunction</a>
+      <TR>
+        <TH ALIGN=LEFT><A HREF="mocTimeseries_${casename}.png">Time series of Max Atlantic MOC at 26.5N</a>
+      <TR>
+        <TD><BR>
+      <TR>
+        <TD><BR>
+EOF
+    fi
+    if [ $generate_mht -eq 1 ]; then
+      cat >> index.html << EOF
+      <TR>
+        <TH ALIGN=LEFT><font color=green size=+1>Meridional Heat Transport (MHT)</font>
+      <TR>
+        <TH ALIGN=LEFT><A HREF="mht_${casename}_years${begin_yr}-${end_yr}.png">Global Ocean MHT</a> 
+      <TR>
+        <TD><BR>
+      <TR>
+        <TD><BR>
+EOF
+    fi
+    if [ $generate_nino34 -eq 1 ]; then
+      cat >> index.html << EOF
+      <TR>
+        <TH ALIGN=LEFT><font color=green size=+1>Nino3.4 Index</font>
+      <TR>
+        <TH ALIGN=LEFT><A HREF="NINO34_${casename}.png">Time series of Nino3.4 Index</a>
+      <TR>
+        <TH ALIGN=LEFT><A HREF="NINO34_spectra_${casename}.png">Nino3.4 Power Spectrum</a>
+      <TR>
+        <TH><BR>
+      <TR>
+        <TH><BR>
+EOF
+    fi
+    if [ $generate_ohc_trends -eq 1 ]; then
+      cat >> index.html << EOF
+      <TR>
+        <TH ALIGN=LEFT><font color=green size=+1>T, S, OHC anomaly trends with depth</font>
+      <TR>
+        <TH ALIGN=LEFT><A HREF="TAnomalyZ_global_${casename}.png">T anomaly vs depth/time</a>
+      <TR>
+        <TH ALIGN=LEFT><A HREF="SAnomalyZ_global_${casename}.png">S anomaly vs depth/time</a>
+      <TR>
+        <TH ALIGN=LEFT><A HREF="OHCAnomalyZ_global_${casename}.png">OHC anomaly vs depth/time</a>
+EOF
+    fi
+    cat >> index.html << EOF
+    </TABLE>
+EOF
+  fi
 fi
 
 # Generate ENSO diags section

--- a/bash_scripts/plot_climo.bash
+++ b/bash_scripts/plot_climo.bash
@@ -75,6 +75,12 @@ while [ $k -lt $n_var ]; do
 			--ref_interp_grid $ref_interp_grid \
 			--ref_interp_method $ref_interp_method \
 			--plots_dir $plots_dir >& $log_dir/plot_climo_$casename-$ref_casename.$var.$season_name.log &
+        exstatus=$?
+        if [ $exstatus -ne 0 ]; then
+          echo
+          echo "Failed plotting $var climatology"
+          exit 1
+        fi
 
       else
         python python/plot_climo.py \
@@ -94,6 +100,12 @@ while [ $k -lt $n_var ]; do
 			--ref_interp_grid $ref_interp_grid \
 			--ref_interp_method $ref_interp_method \
 			--plots_dir $plots_dir >& $log_dir/plot_climo_$casename-$ref_casename.$var.$season_name.log &
+        exstatus=$?
+        if [ $exstatus -ne 0 ]; then
+          echo
+          echo "Failed plotting $var climatology"
+          exit 1
+        fi
       fi
 
       ns=$((ns+1))

--- a/bash_scripts/plot_enso_diags_time_series.bash
+++ b/bash_scripts/plot_enso_diags_time_series.bash
@@ -17,7 +17,7 @@ ref_begin_yr=$7
 ref_end_yr=$8
 var_list_file=$9
 
-# Read in variable list for plotting climatologies  diagnostics
+# Read in variable list for plotting climatologies diagnostics
 source $var_list_file
 
 n_var=${#var_set[@]}
@@ -71,6 +71,12 @@ for ((k=0; k<$n_var; k++)); do
 							--no_ann 1 \
 							--stdize 0 \
 							--plots_dir $plots_dir >& $log_dir/plot_time_series_${casename}_${var}_$index_set_name.log &
+        exstatus=$?
+        if [ $exstatus -ne 0 ]; then
+          echo
+          echo "Failed plotting Nino timeseries"
+          exit 1
+        fi
 
 done
 
@@ -80,7 +86,3 @@ echo Waiting for jobs to complete ...
 echo
 
 wait
-
- 	
-
-

--- a/bash_scripts/plot_enso_evolution.bash
+++ b/bash_scripts/plot_enso_evolution.bash
@@ -85,7 +85,12 @@ for ((k=0; k<$n_var; k++)); do
 							--reg ${reg[@]} \
 							--reg_name ${reg_name[@]} \
 							--plots_dir $plots_dir >& $log_dir/plot_regr_lead_lag_${casename}_${var}_vs_${index_reg_name}_$season_name.log &
-
+        exstatus=$?
+        if [ $exstatus -ne 0 ]; then
+          echo
+          echo "Failed plotting Nino regression plots for var=$var"
+          exit 1
+        fi
 done
 
 
@@ -96,7 +101,3 @@ echo
 wait
 echo ... Done.
 echo
- 	
-
-
-

--- a/bash_scripts/plot_enso_feedbacks.bash
+++ b/bash_scripts/plot_enso_feedbacks.bash
@@ -94,9 +94,14 @@ for ((k=0; k<$n_var; k++)); do
 								--reg_name ${reg_name[@]} \
 								--split_yfit_x_0 $split_yfit_x_0 \
 								--plots_dir $plots_dir >& $log_dir/plot_enso_feedbacks_${casename}_${var}_vs_${index_reg_name}_$season_name.log &
+                exstatus=$?
+                if [ $exstatus -ne 0 ]; then
+                  echo
+                  echo "Failed plotting Nino regression plots for var=$var, season=$season_name"
+                  exit 1
+                fi
 	done
 done
-
 
 echo
 echo Waiting for jobs to complete ...
@@ -105,7 +110,3 @@ echo
 wait
 echo ... Done.
 echo
- 	
-
-
-

--- a/bash_scripts/plot_enso_seasonality.bash
+++ b/bash_scripts/plot_enso_seasonality.bash
@@ -72,9 +72,14 @@ for ((k=0; k<$n_var; k++)); do
 							--no_ann 1 \
 							--stdize 0 \
 							--plots_dir $plots_dir >& $log_dir/plot_seasonality_${casename}_${var}_$index_set_name.log &
+        exstatus=$?
+        if [ $exstatus -ne 0 ]; then
+          echo
+          echo "Failed plotting Nino index seasonality for var=$var"
+          exit 1
+        fi
 
 done
-
 
 echo
 echo Waiting for jobs to complete ...
@@ -83,7 +88,3 @@ echo
 wait
 echo ... Done.
 echo
-
- 	
-
-

--- a/bash_scripts/plot_multiple_index_same_plot.bash
+++ b/bash_scripts/plot_multiple_index_same_plot.bash
@@ -84,6 +84,12 @@ python python/plot_multiple_index_same_plot.py -d True --indir ${scratch_dir_ind
 						--no_ann 1 1\
 						--stdize 0 0\
 						--plots_dir $plots_dir >& $log_dir/plot_time_series_${casename}_$index_set_name.log &
+exstatus=$?
+if [ $exstatus -ne 0 ]; then
+  echo
+  echo "Failed plotting Nino indeces in the same plot"
+  exit 1
+fi
 
 
 

--- a/bash_scripts/plot_regr_nino34_fields.bash
+++ b/bash_scripts/plot_regr_nino34_fields.bash
@@ -92,9 +92,14 @@ for ((k=0; k<$n_var; k++)); do
 								--reg ${reg[@]} \
 								--reg_name ${reg_name[@]} \
 								--plots_dir $plots_dir >& $log_dir/plot_regr_${casename}_${var}_vs_${index_reg_name}_$season_name.log &
+                exstatus=$?
+                if [ $exstatus -ne 0 ]; then
+                  echo
+                  echo "Failed plotting Nino regression plots for var=$var, season=$season_name"
+                  exit 1
+                fi
 	done
 done
-
 
 echo
 echo Waiting for jobs to complete ...
@@ -103,7 +108,3 @@ echo
 wait
 echo ... Done.
 echo
- 	
-
-
-

--- a/bash_scripts/plot_stddev.bash
+++ b/bash_scripts/plot_stddev.bash
@@ -75,10 +75,14 @@ for ((k=0; k<$n_var; k++)); do
 			--ref_interp_grid $ref_interp_grid \
 			--ref_interp_method $ref_interp_method \
 			--plots_dir $plots_dir >& $log_dir/plot_stddev_${reg}_$casename-$ref_casename.$var.$season_name.log &
-
+                exstatus=$?
+                if [ $exstatus -ne 0 ]; then
+                  echo
+                  echo "Failed plotting Nino stddev plots for var=$var, season=$season_name"
+                  exit 1
+                fi
 	done
 done
-
 
 echo
 echo Waiting for jobs to complete ...
@@ -87,7 +91,3 @@ echo
 wait
 echo ... Done.
 echo
- 
-	
-
-

--- a/bash_scripts/plot_time_series.bash
+++ b/bash_scripts/plot_time_series.bash
@@ -65,6 +65,12 @@ while [ $k -lt $n_var ]; do
 			--regs ${regs[@]} \
 			--names ${names[@]} \
 			--plots_dir $plots_dir >& $log_dir/plot_time_series_${casename}_$var.log &
+   exstatus=$?
+   if [ $exstatus -ne 0 ]; then
+     echo
+     echo "Failed plotting timeseries plots for var=$var"
+     exit 1
+   fi
 
    k=$((k+1))
 done

--- a/bash_scripts/plot_tropical_pacific_meridional_avg.bash
+++ b/bash_scripts/plot_tropical_pacific_meridional_avg.bash
@@ -74,13 +74,18 @@ while [ $k -lt $n_var ]; do
 								--reg $reg \
 								--reg_name $reg_name \
 								--plots_dir $plots_dir >& $log_dir/plot_meridional_avg_${reg}_${casename}_${var}_$season_name.log &
+                exstatus=$?
+                if [ $exstatus -ne 0 ]; then
+                  echo
+                  echo "Failed plotting Nino Tropical Pacific averages for var=$var, season=$season_name"
+                  exit 1
+                fi
 
 		i=$((i+1))
 	done
 
 	k=$((k+1))
 done
-
 
 echo
 echo Waiting for jobs to complete ...
@@ -89,7 +94,3 @@ wait
 echo
 echo ... Done
 echo
-
- 	
-
-

--- a/run_aprime.bash
+++ b/run_aprime.bash
@@ -30,6 +30,7 @@
 #            ref_case_v0: baseline ACME v0 case for comparsion to POP/CICE ocn/ice
 #                         (pre-processed diagnostics)
 #            generate_atm_diags: flag to produce atm diagnostics
+#            generate_atm_enso_diags: flag to produce additional, ENSO-related, atm diagnostics
 #            generate_ocnice_diags: flag to produce ocn/ice diagnostics
 #            run_batch_script: flag to submit to batch queue or not
 #       3. execute: ./run_aprime_$user.bash 
@@ -48,19 +49,20 @@
 #                   to 1 and choose begin_yr_ts, end_yr_ts to include only data
 #                   that have been short-term-archived).
 #               mpaso.rst.0002-01-01_00000.nc (or any other restart file)
+#               mpaso.hist.am.meridionalHeatTransport.0001-02-01.nc (or any mpaso.hist.am.meridionalHeatTransport file)
 #               streams.ocean
+#               mpas-o_in
 #       - mpas-cice files:
 #               mpascice.hist.am.timeSeriesStatsMonthly.*.nc
+#               mpascice.rst.0002-01-01_00000.nc (or any other mpas-cice restart file)
 #               streams.cice
+#               mpas-cice_in
 #
 # Meaning of acronyms/words used in variable names below:
 #	test:		 Test case
 #	ref:		 Reference case or 'obs'
 #	ts: 		 Time series; e.g. test_begin_yr_ts
-#       climateIndex_ts: Time series for climate indexes such as Nino3.4.
-#                        NB: if begin_yr_climateIndex_ts=1 and end_yr_climateIndex_ts=9999,
-#                        the climate index time series is computed over the full
-#                        available data set
+#       climateIndex_ts: Time series for climate indexes such as Nino3.4
 #	climo: 		 Climatology
 #	begin_yr: 	 Model year to start analysis 
 #	end_yr:		 Model year to end analysis
@@ -245,20 +247,18 @@ export generate_html=1
 #   If run_batch_script=false, aprime_atm_diags.bash and aprime_ocnice_diags.bash are called directly.
 #   If run_batch_script=true, aprime_atm_diags.bash and aprime_ocnice_diags.bash are called within
 #     a machine-specific batch script (one script for atm and one for ocn/ice diags). In this case,
-#     atmosphere diagnostics are run in background mode onto a single compute node. Ocean/ice
-#     diagnostics, on the other hand, grab a number of compute nodes set by 'mpas_analysis_tasks':
-#     each ocn/ice task is run on a different node. If all ocn/ice diagnostics are run (by activating
-#     all the 'generate' options above), the total number of tasks is equal to 10, hence the default
-#     here is 10. The user can decide to reduce mpas_analysis_tasks accordingly, if asking to compute
-#     a reduced set of ocn/ice diagnostics. Finally, the user can set the walltime (default is 1hr
-#     for atm and 1hr for ocn/ice diags, which is fine to compute ~20 year climatology at low-resolution).
-#   Finally, choose whether to run ncclimo in parallel mode. In that case, set ncclimoParallelMode to
-#   "bck", and nclimo will launch 12 parallel tasks on a single node to compute 12 monthly
-#   climatologies. Otherwise, leave ncclimoParallelMode="serial".
+#     both atmosphere and ocn/ice diagnostics are run in background mode onto a single compute node
+#     each, using a number of tasks equal to 'mpas_analysis_tasks'. We have determined that
+#     mpas_analysis_tasks=12 is a good choice for most systems, and therefore the user should
+#     NOT change this setting. Parameters that could be set by the user are instead:
+#     -) the walltime (default is 1hr for atm and 1hr for ocn/ice diags)
+#     -) whether to run ncclimo in parallel mode. In that case, set ncclimoParallelMode to
+#        "bck", and nclimo will launch 12 parallel tasks on a single node to compute 12 monthly
+#        climatologies. Otherwise, leave ncclimoParallelMode="serial".
 export run_batch_script=false
-export mpas_analysis_tasks=10
 export batch_walltime="01:00:00" # HH:MM:SS
 export ncclimoParallelMode="bck"
+export mpas_analysis_tasks=12
 ###############################################################################################
 
 ########################################################################
@@ -336,7 +336,7 @@ export uniqueID=`date +%Y-%m-%d_%H%M%S`
 # Check on www_dir, permissions included
 # Create www_dir if it does not exist, purge it if it does
 if [ ! -d $www_dir/$plots_dir_name ]; then
-  mkdir $www_dir/$plots_dir_name
+  mkdir -p $www_dir/$plots_dir_name
 else
   rm -f $www_dir/$plots_dir_name/*
 fi
@@ -368,7 +368,11 @@ elif [ $machname == "lanl" ]; then
   module load python/anaconda-2.7-climate
 fi
 
-# The following is needed for rhea, aims4 and acme1
+# The following is needed to avoid the too-many-open-files problem
+# in xarray. Since we are mostly using ncrcat in MPAS-Analysis v0.6
+# and beyond, this will eventually become outdated (as per v0.6, we
+# are still using xarray 'open_mfdataset' to open pre-processed
+# model data).
 if [ $machname == "aims4" ] || [ $machname == "acme1" ] || [ ${HOSTNAME:0:4} == "rhea" ]; then
   export mpasAutocloseFileLimitFraction=0.02
 else
@@ -448,7 +452,6 @@ if [ $generate_ocnice_diags -eq 1 ]; then
       sed 's@SBATCH --time=.*@SBATCH --time='$batch_walltime'@' ./bash_scripts/batch_ocnice.$machname.bash > $batch_script
       sed -i 's@SBATCH --output=.*@SBATCH --output='$log_dir'/aprime_ocnice_diags.o'$uniqueID'@' $batch_script
       sed -i 's@SBATCH --error=.*@SBATCH --error='$log_dir'/aprime_ocnice_diags.e'$uniqueID'@' $batch_script
-      sed -i 's@SBATCH --nodes=.*@SBATCH --nodes='$mpas_analysis_tasks'@' $batch_script
       echo
       echo "**** Submitting ocn/ice batch script: batch_ocnice.$machname.$uniqueID.bash"
       echo "**** jobID:"
@@ -458,7 +461,6 @@ if [ $generate_ocnice_diags -eq 1 ]; then
       sed 's@PBS -l walltime=.*@PBS -l walltime='$batch_walltime'@' ./bash_scripts/batch_ocnice.$machname.bash > $batch_script
       sed -i 's@PBS -o .*@PBS -o '$log_dir'/aprime_ocnice_diags.o'$uniqueID'@' $batch_script
       sed -i 's@PBS -e .*@PBS -e '$log_dir'/aprime_ocnice_diags.e'$uniqueID'@' $batch_script
-      sed -i 's@PBS -l nodes=.*@PBS -l nodes='$mpas_analysis_tasks'@' $batch_script
       sed -i 's@batch_script=.*@batch_script='$update_wwwdir_script'@' $batch_script
       sed 's@PBS -o .*@PBS -o '$log_dir'/aprime_update_wwwdir.o'$uniqueID'@' \
        ./bash_scripts/batch_update_wwwdir.$machname.bash > $update_wwwdir_script

--- a/run_aprime.bash
+++ b/run_aprime.bash
@@ -472,7 +472,7 @@ if [ $generate_ocnice_diags -eq 1 ]; then
       echo "**** Submitting ocn/ice batch script: batch_ocnice.$machname.$uniqueID.bash"
       echo "**** jobID:"
       sbatch $batch_script
-    elif [ $machname == "olcf" ] || [ $machname == "anvil" ]; then
+    elif [ $machname == "titan" ] || [ $machname == "anvil" ]; then
       update_wwwdir_script="$log_dir/batch_update_wwwdir.$machname.$uniqueID.bash"
       sed 's@PBS -l walltime=.*@PBS -l walltime='$batch_walltime'@' ./bash_scripts/batch_ocnice.$machname.bash > $batch_script
       sed -i 's@PBS -o .*@PBS -o '$log_dir'/aprime_ocnice_diags.o'$uniqueID'@' $batch_script
@@ -529,7 +529,7 @@ if [ $atm_status -eq 0 ]    || [ $atm_status -eq -2 ]   ||
   chmod -R ga+rX $www_dir/$plots_dir_name
 else
   echo
-  echo "Neither atmospheric nor ocn/ice diagnostics were successful. HTML page not generated!"
+  echo "Neither atmospheric nor ocn/ice diagnostics were generated. HTML page also not generated!"
   echo
 fi
 

--- a/run_aprime.bash
+++ b/run_aprime.bash
@@ -146,6 +146,8 @@ elif [ ${HOSTNAME:0:5} == "acme1" ]; then
   export machname="acme1"
 elif [ ${HOSTNAME:0:4} == "wolf" ]; then
   export machname="lanl"
+elif [ ${HOSTNAME:0:6} == "blogin" ] || ([ ${HOSTNAME:0:1} == "b" ] && [[ ${HOSTNAME:1:2} =~ [0-9] ]]); then
+  export machname="anvil"
 else
   echo "Unsupported host $HOSTNAME. Exiting."
   exit 1
@@ -165,6 +167,9 @@ elif [ $machname == "aims4" ] || [ $machname == "acme1" ]; then
 elif [ $machname == "lanl" ]; then
   projdir=/usr/projects/climate/SHARED_CLIMATE
   export www_dir=$output_base_dir/www
+elif [ $machname == "anvil" ]; then
+  projdir=/lcrc/group/acme/lvanroe/APrime_Files
+  export www_dir=$output_base_dir/www
 fi
 
 # ** Reference case variables (similar to test_case variables) **
@@ -176,6 +181,8 @@ elif [ $machname == "olcf" ]; then
 elif [ $machname == "aims4" ] || [ $machname == "acme1" ]; then
   export ref_archive_dir=$projdir/diagnostics/observations/Atm
 elif [ $machname == "lanl" ]; then
+  export ref_archive_dir=$projdir/obs_for_diagnostics
+elif [ $machname == "anvil" ]; then
   export ref_archive_dir=$projdir/obs_for_diagnostics
 fi
 #export ref_case=casename
@@ -196,6 +203,9 @@ elif [ $machname == "aims4" ] || [ $machname == "acme1" ]; then
   export ref_archive_v0_ocndir=/space2/diagnostics/ACMEv0_lowres/${ref_case_v0}/ocn/postprocessing
   export ref_archive_v0_seaicedir=/space2/diagnostics/ACMEv0_lowres/${ref_case_v0}/ice/postprocessing
 elif [ $machname == "lanl" ]; then
+  export ref_archive_v0_ocndir=$projdir/ACMEv0_lowres/${ref_case_v0}/ocn/postprocessing
+  export ref_archive_v0_seaicedir=$projdir/ACMEv0_lowres/${ref_case_v0}/ice/postprocessing
+elif [ $machname == "anvil" ]; then
   export ref_archive_v0_ocndir=$projdir/ACMEv0_lowres/${ref_case_v0}/ocn/postprocessing
   export ref_archive_v0_seaicedir=$projdir/ACMEv0_lowres/${ref_case_v0}/ice/postprocessing
 fi
@@ -312,6 +322,9 @@ elif [ $machname == "aims4" ] || [ $machname == "acme1" ]; then
 elif [ $machname == "lanl" ]; then
   export obs_ocndir=$projdir/observations
   export obs_seaicedir=$projdir/observations/SeaIce
+elif [ $machname == "anvil" ]; then
+  export obs_ocndir=$projdir/observations/Ocean
+  export obs_seaicedir=$projdir/observations/SeaIce
 fi
 export obs_sstdir=$obs_ocndir/SST
 export obs_sssdir=$obs_ocndir/SSS
@@ -366,6 +379,9 @@ elif [ $machname == "lanl" ]; then
   module unload python
   module use $projdir/modulefiles/all
   module load python/anaconda-2.7-climate
+elif [ $machname == "anvil" ]; then
+  unset LD_LIBRARY_PATH
+  soft add +acme-unified-1.1.1-x
 fi
 
 # The following is needed to avoid the too-many-open-files problem
@@ -406,7 +422,7 @@ if [ $generate_atm_diags -eq 1 ]; then
       echo "**** $batch_script"
       echo "**** jobID:"
       sbatch $batch_script
-    elif [ ${HOSTNAME:0:5} == "titan" ]; then
+    elif [ ${HOSTNAME:0:5} == "titan" ] || [ $machname == "anvil" ]; then
       update_wwwdir_script="$log_dir/batch_update_wwwdir.$machname.$uniqueID.bash"
       sed 's@PBS -l walltime=.*@PBS -l walltime='$batch_walltime'@' ./bash_scripts/batch_atm.$machname.bash > $batch_script
       sed -i 's@PBS -o .*@PBS -o '$log_dir'/aprime_atm_diags.o'$uniqueID'@' $batch_script
@@ -456,7 +472,7 @@ if [ $generate_ocnice_diags -eq 1 ]; then
       echo "**** Submitting ocn/ice batch script: batch_ocnice.$machname.$uniqueID.bash"
       echo "**** jobID:"
       sbatch $batch_script
-    elif [ $machname == "olcf" ]; then
+    elif [ $machname == "olcf" ] || [ $machname == "anvil" ]; then
       update_wwwdir_script="$log_dir/batch_update_wwwdir.$machname.$uniqueID.bash"
       sed 's@PBS -l walltime=.*@PBS -l walltime='$batch_walltime'@' ./bash_scripts/batch_ocnice.$machname.bash > $batch_script
       sed -i 's@PBS -o .*@PBS -o '$log_dir'/aprime_ocnice_diags.o'$uniqueID'@' $batch_script


### PR DESCRIPTION
Integrate MPAS-Analysis v0.6.5, which 1) changes parallel tasks to use one single node, 2) computes all ocean/ice climatologies and process data for all timeseries as two prerequisites tasks before computing any diagnostics,  3) loads data for timeseries using ncrcat instead of xarray, and 4) adds python 3 support to MPAS-Analysis tasks.

Also, addresses some misc issues such as #16, #13 and hopefully most of #11.

Finally, adds anvil support, addressing #2.